### PR TITLE
Update VSSDK to the latest version and clear warnings

### DIFF
--- a/CodeiumVS/CodeiumVS.csproj
+++ b/CodeiumVS/CodeiumVS.csproj
@@ -126,8 +126,8 @@
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.507" ExcludeAssets="Runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Language">
-      <Version>17.8.222</Version>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>17.8.37222</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK.VsixSuppression">
       <Version>14.1.37</Version>

--- a/CodeiumVS/CodeiumVSPackage.cs
+++ b/CodeiumVS/CodeiumVSPackage.cs
@@ -137,12 +137,9 @@ public sealed class CodeiumVSPackage : ToolkitPackage
                 var browserKey = Registry.ClassesRoot.OpenSubKey(@"HTTP\shell\open\command", false);
 
                 //If browser path wasn’t found, try Win Vista (and newer) registry key
-                if (browserKey == null)
-                {
-                    browserKey =
+                browserKey ??=
                     Registry.CurrentUser.OpenSubKey(
                     urlAssociation, false);
-                }
                 var path = CleanifyBrowserPath(browserKey.GetValue(null) as string);
                 browserKey.Close();
                 return path;

--- a/CodeiumVS/Proposal/Mapper.cs
+++ b/CodeiumVS/Proposal/Mapper.cs
@@ -92,19 +92,17 @@ internal class LanguageEqualityComparer : IEqualityComparer<LangInfo>
 
 internal class Mapper
 {
-    private static readonly Dictionary<string, LangInfo> _languagesByIdentifier = KnownLanguages.Default.Distinct<LangInfo>(new LanguageEqualityComparer()).ToDictionary((LangInfo x) => x.Identifier.ToLowerInvariant());
+    private static readonly Dictionary<string, LangInfo> _languagesByIdentifier =
+        KnownLanguages.Default.Distinct(new LanguageEqualityComparer())
+        .ToDictionary((LangInfo x) => x.Identifier.ToLowerInvariant());
 
-    private static readonly Dictionary<string, LangInfo> _languagesByName = KnownLanguages.Default.ToDictionary((LangInfo x) => x.Name.ToLowerInvariant());
+    private static readonly Dictionary<string, LangInfo> _languagesByName = 
+        KnownLanguages.Default.ToDictionary((LangInfo x) => x.Name.ToLowerInvariant());
 
-    private static readonly ConcurrentDictionary<IContentType, string> _extensionByContentType = new ConcurrentDictionary<IContentType, string>();
-
-    private static readonly ConcurrentDictionary<string, LangInfo> _languageByExtension = new ConcurrentDictionary<string, LangInfo>();
-
-    private static readonly ConcurrentDictionary<IContentType, LangInfo> _contentTypeMap = new ConcurrentDictionary<IContentType, LangInfo>();
-
-    private static readonly ConcurrentDictionary<IContentType, bool> _typeCharTriggerSupportedByContentType = new ConcurrentDictionary<IContentType, bool>();
-
-    private static readonly ConcurrentDictionary<IContentType, bool> _formatDocumentSupportedByContentType = new ConcurrentDictionary<IContentType, bool>();
+    private static readonly ConcurrentDictionary<IContentType, string  > _extensionByContentType               = new();
+    private static readonly ConcurrentDictionary<string      , LangInfo> _languageByExtension                  = new();
+    private static readonly ConcurrentDictionary<IContentType, LangInfo> _contentTypeMap                       = new();
+    private static readonly ConcurrentDictionary<IContentType, bool    > _formatDocumentSupportedByContentType = new();
 
     public static LangInfo GetLanguage(DocumentView docView)
     {
@@ -135,7 +133,7 @@ internal class Mapper
         foreach (IContentType baseType in type.BaseTypes)
         {
             LangInfo language = FindLanguage(baseType, null);
-            if ((object)language != null && language != KnownLanguages.Fallback)
+            if (language is not null && language != KnownLanguages.Fallback)
             {
                 return language;
             }


### PR DESCRIPTION
We have been using an outdated version of VSSDK, this PR updates it to the latest [17.8.37222](https://www.nuget.org/packages/Microsoft.VisualStudio.SDK/17.8.37222) version.

This will still work on version 17.5.5 and later, I confirmed it by building and running it using the [17.6.36389](https://www.nuget.org/packages/Microsoft.VisualStudio.SDK/17.6.36389) version (closest to 15.5.5).

This also clears all the annoying warnings, except for one:

> NU1603: Microsoft.VisualStudio.Language 17.8.222 depends on StreamJsonRpc (>= 2.17.3) but StreamJsonRpc 2.17.3 was not found. An approximate best match of StreamJsonRpc 2.17.8 was resolved.

I don't even know why they warn about this if it specified `>=` and not `==`. The warning is meaningless but turning it off can cause hard-to-track-down problems in the future.