### PR TITLE
Better handling for the Language Server process (#3)

### DIFF
--- a/CodeiumVS/CodeiumVS.csproj
+++ b/CodeiumVS/CodeiumVS.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Proposal\CodeiumProposalSourceProvider.cs" />
     <Compile Include="Proposal\Mapper.cs" />
     <Compile Include="Utilities\Extensions.cs" />
+    <Compile Include="Utilities\ProcessExtensions.cs" />
     <Compile Include="Utilities\TextHighlighter.cs" />
     <Compile Include="Utilities\CodeAnalyzer.cs" />
     <Compile Include="Utilities\MefProvider.cs" />

--- a/CodeiumVS/CodeiumVSPackage.cs
+++ b/CodeiumVS/CodeiumVSPackage.cs
@@ -96,7 +96,10 @@ public sealed class CodeiumVSPackage : ToolkitPackage
         if (!IsSignedIn())
         {
             KeyValuePair<string, Action>[] actions = [
-                new KeyValuePair<string, Action>("Sign in", delegate { _ = LanguageServer.SignInAsync(); }),
+                new KeyValuePair<string, Action>("Sign in", delegate 
+                { 
+                    ThreadHelper.JoinableTaskFactory.RunAsync(LanguageServer.SignInAsync).FireAndForget(true);
+                }),
                 new KeyValuePair<string, Action>("Use authentication token", delegate { new EnterTokenDialogWindow().ShowDialog(); }),
             ];
 
@@ -107,9 +110,7 @@ public sealed class CodeiumVSPackage : ToolkitPackage
             await NotificationAuth.CloseAsync();
         }
 
-        // find the ChatToolWindow and update it
-        ChatToolWindow chatWindowPane = (await FindWindowPaneAsync(typeof(ChatToolWindow), 0, false, DisposalToken)) as ChatToolWindow;
-        chatWindowPane?.Reload();
+        ChatToolWindow.Instance?.Reload();
     }
 
     public static string GetDefaultBrowserPath()

--- a/CodeiumVS/LanguageServer/LanguageServerController.cs
+++ b/CodeiumVS/LanguageServer/LanguageServerController.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.VisualStudio.Text;
+﻿using CodeiumVS.Packets;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Newtonsoft.Json;
 using ProtoBuf;
 using System.IO;
 using System.Linq;
-using CodeiumVS.Packets;
 using WebSocketSharp;
 
 namespace CodeiumVS;
@@ -25,26 +24,22 @@ public class LanguageServerController
 #pragma warning disable VSTHRD103 // Call async methods when in an async method
         void OnOpen(object sender, EventArgs e)
         {
-            WebSocket ws = sender as WebSocket;
-            Package.Log($"Connected to {ws.Url}");
+            Package.Log($"Language Server Controller: Connected to {ws.Url}");
         }
 
-        void OnClose(object sender, EventArgs e)
+        void OnClose(object sender, CloseEventArgs e)
         {
-            WebSocket ws = sender as WebSocket;
-            Package.Log($"Disconnected from {ws.Url}");
+            // We don't actually do anything here, just log that we disconnected
+            // the LanguageServer will handle the reconnection
+            Package.Log("Language Server Controller: Disconnected unexpectedly, retrying to connect...");
         }
 
-        void OnMessage(object sender, EventArgs e)
+        void OnMessage(object sender, MessageEventArgs msg)
         {
-            MessageEventArgs msg = e as MessageEventArgs;
             if (!msg.IsBinary) return;
 
             using MemoryStream stream = new(msg.RawData);
             WebServerResponse request = Serializer.Deserialize<WebServerResponse>(stream);
-            string text = JsonConvert.SerializeObject(request);
-
-            Package.Log($"OnMessage: {text}");
 
             if (request.ShouldSerializeopen_file_pointer())
             {
@@ -56,12 +51,11 @@ public class LanguageServerController
                 var data = request.insert_at_cursor;
                 InsertText(data.text);
             }
-
         }
 
-        void OnError(object sender, EventArgs e)
+        void OnError(object sender, WebSocketSharp.ErrorEventArgs error)
         {
-            Package.Log("OnError\n");
+            Package.Log($"Language Server Controller: Error '{error.Message}'; Exception: {error.Exception}");
         }
 #pragma warning restore VSTHRD103 // Call async methods when in an async method
 
@@ -124,8 +118,7 @@ public class LanguageServerController
             docView.TextView.Caret.EnsureVisible();
         }).FireAndForget();
     }
-
-
+    
     public async Task ExplainCodeBlockAsync(string filePath, Language language, CodeBlockInfo codeBlockInfo)
     {
         var request = WebChatServer.NewRequest();
@@ -139,8 +132,8 @@ public class LanguageServerController
             }
         };
 
-        request.Send(ws);
-        await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
+        if (request.Send(ws))
+            await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
     }
 
     public async Task ExplainFunctionAsync(string filePath, FunctionInfo functionInfo)
@@ -156,8 +149,8 @@ public class LanguageServerController
             }
         };
 
-        request.Send(ws);
-        await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
+        if (request.Send(ws))
+            await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
     }
     
     public async Task GenerateFunctionUnitTestAsync(string instructions, string filePath, FunctionInfo functionInfo)
@@ -174,8 +167,8 @@ public class LanguageServerController
             }
         };
 
-        request.Send(ws);
-        await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
+        if (request.Send(ws))
+            await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
     }
 
     public async Task GenerateFunctionDocstringAsync(string filePath, FunctionInfo functionInfo)
@@ -191,8 +184,8 @@ public class LanguageServerController
             }
         };
 
-        request.Send(ws);
-        await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
+        if (request.Send(ws))
+            await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
     }
 
     public async Task RefactorCodeBlockAsync(string prompt, string filePath, Language language, CodeBlockInfo codeBlockInfo)
@@ -209,8 +202,8 @@ public class LanguageServerController
             }
         };
 
-        request.Send(ws);
-        await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
+        if (request.Send(ws))
+            await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
     }
 
     public async Task RefactorFunctionAsync(string prompt, string filePath, FunctionInfo functionInfo)
@@ -227,8 +220,8 @@ public class LanguageServerController
             }
         };
 
-        request.Send(ws);
-        await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
+        if (request.Send(ws))
+            await Package.ShowToolWindowAsync(typeof(ChatToolWindow), 0, create: true, Package.DisposalToken);
     }
 
     public void Disconnect()
@@ -273,10 +266,18 @@ internal static class WebChatServer
         return request;
     }
 
-    internal static void Send(this WebServerRequest request, WebSocket ws)
+    internal static bool Send(this WebServerRequest request, WebSocket ws)
     {
+        if (!ws.IsAlive)
+        {
+            CodeiumVSPackage.Instance.Log("Language Server Controller: Unable to send the request because the connection is closed.");
+            return false;
+        }
+
         using MemoryStream memoryStream = new();
         Serializer.Serialize(memoryStream, request);
         ws.SendAsync(memoryStream.ToArray(), delegate (bool e) { });
+
+        return true;
     }
 }

--- a/CodeiumVS/Proposal/CodeiumProposalSourceProvider.cs
+++ b/CodeiumVS/Proposal/CodeiumProposalSourceProvider.cs
@@ -60,6 +60,9 @@ internal class CodeiumProposalSourceProvider : ProposalSourceProviderBase
         string proposalId = ((SuggestionAcceptedEventArgs)e).FinalProposal.ProposalId;
 
         CodeiumVSPackage.Instance.Log("Accepted completion " + proposalId);
-        _ = CodeiumVSPackage.Instance.LanguageServer.AcceptCompletionAsync(proposalId);
+        ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+        {
+            await CodeiumVSPackage.Instance.LanguageServer.AcceptCompletionAsync(proposalId);
+        }).FireAndForget(true);
     }
 }

--- a/CodeiumVS/Utilities/ProcessExtensions.cs
+++ b/CodeiumVS/Utilities/ProcessExtensions.cs
@@ -1,0 +1,86 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace CodeiumVS.Utilities;
+
+#pragma warning disable IDE0049 // Name can be simplified
+
+public class ProcessExtensions
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr a, string lpName);
+
+    [DllImport("kernel32.dll")]
+    private static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+    private enum JobObjectInfoType
+    {
+        AssociateCompletionPortInformation = 7,
+        BasicLimitInformation = 2,
+        BasicUIRestrictions = 4,
+        EndOfJobTimeInformation = 6,
+        ExtendedLimitInformation = 9,
+        SecurityLimitInformation = 5,
+        GroupInformation = 11
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public Int64 PerProcessUserTimeLimit;
+        public Int64 PerJobUserTimeLimit;
+        public UInt32 LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public UInt32 ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public UInt32 PriorityClass;
+        public UInt32 SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public UInt64 ReadOperationCount;
+        public UInt64 WriteOperationCount;
+        public UInt64 OtherOperationCount;
+        public UInt64 ReadTransferCount;
+        public UInt64 WriteTransferCount;
+        public UInt64 OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    public static void MakeProcessExitOnParentExit(Process process)
+    {
+        IntPtr hJob = CreateJobObject(IntPtr.Zero, null);
+
+        var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+        info.BasicLimitInformation.LimitFlags = 0x2000; // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+        int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+        IntPtr extendedInfoPtr = Marshal.AllocHGlobal(length);
+        Marshal.StructureToPtr(info, extendedInfoPtr, false);
+
+        if (!SetInformationJobObject(hJob, JobObjectInfoType.ExtendedLimitInformation, extendedInfoPtr, (uint)length))
+        {
+            throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        AssignProcessToJobObject(hJob, process.Handle);
+    }
+}
+
+#pragma warning restore IDE0049 // Name can be simplified


### PR DESCRIPTION
Summary:
- The language server process now closes when Visual Studio crashes.
- Detect when the child process restarts to reconnect to its websocket and reload the chat window.
- Re-open the host process when it exits and do the same as above.
- Fixed race condition in the webview2, might fix #5.
- Use `JoinableTaskFactory.RunAsync` instead of discards.