### PR TITLE
Fix function name recognition when refactoring function

### DIFF
--- a/CodeiumVS/Utilities/CodeAnalyzer.cs
+++ b/CodeiumVS/Utilities/CodeAnalyzer.cs
@@ -130,7 +130,8 @@ internal static class CodeAnalyzer
         ) return null;
 
         var splits = desc.Split('(');
-        string functionName = splits[0].Split(' ').Last();
+        string fullname = splits[0].Split(' ').Last();
+        string name = fullname.Split(':').Last().Split('.').Last();
         string parameters = "";
 
         if (splits.Length >= 2)
@@ -143,7 +144,7 @@ internal static class CodeAnalyzer
             parameters = parameters.Substring(0, parameters.LastIndexOf(')'));
         }
 
-        return new(functionName, parameters, spans[0]);
+        return new(fullname, name, parameters, spans[0]);
     }
 
     public static FunctionBlock? GetFunctionBlock(IWpfTextView view, int line, int column)

--- a/CodeiumVS/Utilities/Extensions.cs
+++ b/CodeiumVS/Utilities/Extensions.cs
@@ -62,10 +62,18 @@ internal abstract class TextViewExtension<ViewType, ExtensionType> : PropertyOwn
     }
 }
 
-internal class FunctionBlock(string name, string @params, TextSpan span)
+internal class FunctionBlock(string fullname, string name, string @params, TextSpan span)
 {
+    // full name of the function, including namespaces and classes
+    public readonly string FullName = fullname;
+
+    // short name of the function
     public readonly string Name = name;
+    
+    // parameters, not including the braces
     public readonly string Params = @params;
+
+    // span of the function body
     public readonly TextSpan Span = span;
 }
 


### PR DESCRIPTION
When a function belongs to a namespace, we should trim the namespace:

For example, the using `vsLanguageBlock.GetCurrentBlock()` on the following C++ code:

```cpp
namespace MyNamespace {
    class MyClass {
    public:
        void DoSomething(int a1, bool a2){
            // ...
        }
    }
}
```
will return this as a description:
```
void MyNamespace::MyClass.DoSomething(int a1, bool a2)
```
which will be parsed as:
```cs
fullname   = "MyNamespace::MyClass.DoSomething"
name       = "DoSomething"
parameters = "int a1, bool a2"
```

Without an accurate function name, when the language server processes it, it will fail to parse the AST tree. We probably switch to regex or other more reliable methods in the future, as I have only tested this for C# and C++.