### PR TITLE
Empty Refactor code window's Input prompt when it's closed

### DIFF
--- a/CodeiumVS/Windows/RefactorCodeDialogWindow.cs
+++ b/CodeiumVS/Windows/RefactorCodeDialogWindow.cs
@@ -58,6 +58,7 @@ public partial class RefactorCodeDialogWindow : DialogWindow
     private void CloseDialog()
     {
         Visibility = Visibility.Hidden;
+        InputPrompt.Text = string.Empty;
     }
 
     private void NewContext(Languages.LangInfo languageInfo)


### PR DESCRIPTION
Empty the refactor code window input prompt when it's closed so that it's not there anymore the next time the window is opened.