### PR TITLE
Add commands shortcuts

### DIFF
--- a/CodeiumVS/VSCommandTable.vsct
+++ b/CodeiumVS/VSCommandTable.vsct
@@ -175,4 +175,13 @@
 		<GuidSymbol name="ChatToolWindow" value="{1a46fd64-28d5-434c-8eb3-17a02d419b53}"/>
 		
 	</Symbols>
+
+	<KeyBindings>
+		<!-- CMDSETID_StandardCommandSet97 for global shortcuts, GUID_TextEditorFactory for editor only shortcuts
+			 How to find them: https://stackoverflow.com/a/64912040/13253010 -->
+		<KeyBinding guid="CodeiumVS" id="OpenChatWindow"    editor="CMDSETID_StandardCommandSet97" mod1="Alt" mod2="Alt" key1="C" key2="C" />
+		<KeyBinding guid="CodeiumVS" id="ExplainCodeBlock"  editor="GUID_TextEditorFactory"        mod1="Alt" mod2="Alt" key1="C" key2="E" />
+		<KeyBinding guid="CodeiumVS" id="RefactorCodeBlock" editor="GUID_TextEditorFactory"        mod1="Alt" mod2="Alt" key1="C" key2="R" />
+	</KeyBindings>
+	
 </CommandTable>


### PR DESCRIPTION
Due to a large number of key combinations in Visual Studio are already taken, I've decided that all shortcuts related to Codeium should be prefixed with <kbd>ALT+C</kbd>
- <kbd>ALT+C ALT+C</kbd>: Open chat window
- <kbd>ALT+C ALT+E</kbd>: Explain code block
- <kbd>ALT+C ALT+R</kbd>: Refactor function

Deciding the key combination is not easy, as it greatly impacts users' workflow. The considerations that led to this decision were:
- The <kbd>ALT+C</kbd> prefix combination is not used by default and [rarely used by other extensions](https://github.com/search?q=mod1%3D%22Alt%22+key1%3D%22C%22&type=code). It also stands for <ins>C</ins>odeium.
- The most used command is Open chat window, which was set to <kbd>ALT+C ALT+C</kbd> so that the users could hold <kbd>ALT</kbd> and press <kbd>C</kbd> twice for convenience.
- The <kbd>C</kbd>, <kbd>E</kbd>, and <kbd>R</kbd> could be pressed easily using one (left) hand instead of requiring both hands.