### PR TITLE
Handle errors when initializing the extension

### DIFF
--- a/CodeiumVS/InlineDiff/InlineDiffAdornment.cs
+++ b/CodeiumVS/InlineDiff/InlineDiffAdornment.cs
@@ -471,8 +471,8 @@ internal class InlineDiffAdornment : TextViewExtension<IWpfTextView, InlineDiffA
         // format it
         try
         {
-            DTE2 dte = (DTE2)ServiceProvider.GlobalProvider.GetService(typeof(DTE));
-            dte.ExecuteCommand("Edit.FormatSelection");
+            DTE2? dte = ServiceProvider.GlobalProvider.GetService(typeof(DTE)) as DTE2;
+            dte?.ExecuteCommand("Edit.FormatSelection");
 
             // this doesn't work
             //var guid = VSConstants.CMDSETID.StandardCommandSet2K_guid;

--- a/CodeiumVS/InlineDiff/InlineDiffView.cs
+++ b/CodeiumVS/InlineDiff/InlineDiffView.cs
@@ -458,18 +458,18 @@ internal class InlineDiffView
 
     private void LeftView_OnClosed(object sender, EventArgs e)
     {
-        LeftView.VisualElement.GotFocus -= LeftView_OnGotFocus;
-        LeftView.VisualElement.LostFocus -= LeftView_OnLostFocus;
-        LeftView.Caret.PositionChanged -= LeftView_OnCaretPositionChanged;
-        LeftView.Closed -= LeftView_OnClosed;
+        LeftView.VisualElement.GotFocus       -= LeftView_OnGotFocus;
+        LeftView.VisualElement.LostFocus      -= LeftView_OnLostFocus;
+        LeftView.Caret.PositionChanged        -= LeftView_OnCaretPositionChanged;
+        LeftView.Closed                       -= LeftView_OnClosed;
     }
 
     private void RightView_OnClosed(object sender, EventArgs e)
     {
-        RightView.VisualElement.GotFocus -= RightView_OnGotFocus;
-        RightView.VisualElement.LostFocus -= RightView_OnLostFocus;
-        RightView.Caret.PositionChanged -= RightView_OnCaretPositionChanged;
-        RightView.Closed -= RightView_OnClosed;
+        RightView.VisualElement.GotFocus      -= RightView_OnGotFocus;
+        RightView.VisualElement.LostFocus     -= RightView_OnLostFocus;
+        RightView.Caret.PositionChanged       -= RightView_OnCaretPositionChanged;
+        RightView.Closed                      -= RightView_OnClosed;
     }
 
     /// <summary>
@@ -481,6 +481,9 @@ internal class InlineDiffView
     {
         _diffBuffer.SnapshotDifferenceChanged -= DiffBuffer_SnapshotDifferenceChanged;
         _viewer.Closed                        -= DifferenceViewer_OnClosed;
+
+        // restore the selected line highlight for the host view
+        ShowSelectedLineForView(_hostView);
     }
 
     /// <summary>


### PR DESCRIPTION
Added a bunch of error checking to functions that are called by `CodeiumVSPackage.InitializeAsync`, which might be related to #17. Also fixed two bugs in the inline diff.