### PR TITLE
Improve various aspects of the Chat Window

### DIFF
--- a/CodeiumVS/InlineDiff/InlineDiffView.cs
+++ b/CodeiumVS/InlineDiff/InlineDiffView.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Utilities;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace CodeiumVs.InlineDiff;
 
@@ -483,7 +484,7 @@ internal class InlineDiffView
         _viewer.Closed                        -= DifferenceViewer_OnClosed;
 
         // restore the selected line highlight for the host view
-        ShowSelectedLineForView(_hostView);
+        _hostView?.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, true);
     }
 
     /// <summary>
@@ -528,9 +529,9 @@ internal class InlineDiffView
     /// <param name="view"></param>
     private void ShowSelectedLineForView(IWpfTextView view)
     {
-        LeftView.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, (view == LeftView));
-        RightView.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, (view == RightView));
-        _hostView.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, (view == _hostView));
+        LeftView?.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, (view == LeftView));
+        RightView?.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, (view == RightView));
+        _hostView?.Options.SetOptionValue(DefaultWpfViewOptions.EnableHighlightCurrentLineId, (view == _hostView));
     }
 
     private void RightView_OnLostFocus(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- The `SetChatThemeAsync` function was previously unreliable, occasionally failing to apply the theme. To improve reliability, the function now uses [`AddScriptToExecuteOnDocumentCreatedAsync`] to add the set-theme script to a list of scripts that are executed upon document load.
- During the chat page loading process, a 10-second timeout has been added to verify if the page has loaded. If not, the user is notified and asked whether they wish to reload the chat.
- As the webview2 operates as a separate HWND, clicking on it does not activate the ToolWindowPane (indicated by a purple strip on the title). This issue has been addressed by manually activating it during the `GotFocus` event. Additionally, the text input is now automatically focused for user convenience.

Also fixed a bug made in #25  

[`AddScriptToExecuteOnDocumentCreatedAsync`]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addscripttoexecuteondocumentcreatedasync?view=webview2-dotnet-1.0.2210.55&devlangs=csharp&f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(Microsoft.Web.WebView2.Core.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync)%3Bk(TargetFrameworkMoniker-.NETFramework%2CVersion%253Dv4.8)%3Bk(DevLang-csharp)%26rd%3Dtrue