### PR TITLE
Downgrade the SDK version to 17.5.33428.388

### DIFF
--- a/CodeiumVS/CodeiumVS.csproj
+++ b/CodeiumVS/CodeiumVS.csproj
@@ -137,7 +137,7 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.8.37222</Version>
+      <Version>17.5.33428.388</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK.VsixSuppression">
       <Version>14.1.37</Version>

--- a/CodeiumVS/InlineDiff/InlineDiffAdornment.cs
+++ b/CodeiumVS/InlineDiff/InlineDiffAdornment.cs
@@ -26,13 +26,19 @@ using System.Windows.Controls;
 
 namespace CodeiumVs.InlineDiff;
 
+internal sealed class Components
+{
+    internal const string DiffAdornmentLayerName = "CodeiumInlineDiffAdornment";
+
+    [Export]
+    [Name(DiffAdornmentLayerName)]
+    [Order(After = "Text")]
+    [TextViewRole(PredefinedTextViewRoles.Document)]
+    internal AdornmentLayerDefinition viewLayerDefinition = null;
+}
+
 internal class InlineDiffAdornment : TextViewExtension<IWpfTextView, InlineDiffAdornment>, ILineTransformSource, IOleCommandTarget
 {
-    [Export(typeof(AdornmentLayerDefinition))]
-    [Name("CodeiumInlineDiffAdornment")]
-    [Order(After = "Text")]
-    private static readonly AdornmentLayerDefinition _codeiumInlineDiffAdornment;
-
     private static readonly LineTransform _defaultTransform   = new(1.0);
     private static MethodInfo? _fnSetInterceptsAggregateFocus = null;
 
@@ -59,7 +65,7 @@ internal class InlineDiffAdornment : TextViewExtension<IWpfTextView, InlineDiffA
     private double _codeBlockHeight    = 0;
 
     private LineTransform _lineTransform = _defaultTransform;
-    private ITagAggregator<InterLineAdornmentTag>? _tagAggregator = null;
+    //private ITagAggregator<InterLineAdornmentTag>? _tagAggregator = null;
 
     public bool HasAdornment => _adornment != null;
     public bool IsAdornmentFocused => HasAdornment && (_adornment.ActiveView != null) && _adornment.ActiveView.VisualElement.IsKeyboardFocused;
@@ -67,7 +73,7 @@ internal class InlineDiffAdornment : TextViewExtension<IWpfTextView, InlineDiffA
     public InlineDiffAdornment(IWpfTextView view) : base(view)
     {
         _vsHostView = _hostView.ToIVsTextView();
-        _layer = _hostView.GetAdornmentLayer("CodeiumInlineDiffAdornment");
+        _layer = _hostView.GetAdornmentLayer(Components.DiffAdornmentLayerName);
 
         _hostView.Closed                += HostView_OnClosed;
         _hostView.LayoutChanged         += HostView_OnLayoutChanged;
@@ -610,19 +616,20 @@ internal class InlineDiffAdornment : TextViewExtension<IWpfTextView, InlineDiffA
     /// <returns></returns>
     private bool IsPeekOnAdornment()
     {
-        ThreadHelper.ThrowIfNotOnUIThread("IsPeekOnAnchor");
-        _tagAggregator ??= IntellisenseUtilities.GetTagAggregator<InterLineAdornmentTag>(_hostView);
+        //Microsoft.VisualStudio.Text.Editor.InterLineAdornmentTag
+        //ThreadHelper.ThrowIfNotOnUIThread("IsPeekOnAnchor");
+        //_tagAggregator ??= IntellisenseUtilities.GetTagAggregator<InterLineAdornmentTag>(_hostView);
 
-        SnapshotSpan extent = _leftTrackingSpan.GetSpan(_hostView.TextSnapshot);
+        //SnapshotSpan extent = _leftTrackingSpan.GetSpan(_hostView.TextSnapshot);
 
-        foreach (IMappingTagSpan<InterLineAdornmentTag> tag in _tagAggregator.GetTags(extent))
-        {
-            if (!tag.Tag.IsAboveLine && tag.Span.GetSpans(_hostView.TextSnapshot).IntersectsWith(extent))
-            {
-                return true;
-            }
-        }
-        return false;
+        //foreach (IMappingTagSpan<InterLineAdornmentTag> tag in _tagAggregator.GetTags(extent))
+        //{
+        //    if (!tag.Tag.IsAboveLine && tag.Span.GetSpans(_hostView.TextSnapshot).IntersectsWith(extent))
+        //    {
+        //        return true;
+        //    }
+        //}
+        return true;
     }
 
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread

--- a/CodeiumVS/Proposal/CodeiumProposalManager.cs
+++ b/CodeiumVS/Proposal/CodeiumProposalManager.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.Text.Editor;
 
 namespace CodeiumVS;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 internal class CodeiumProposalManager : ProposalManagerBase
 {
     private readonly IWpfTextView view;
@@ -62,3 +63,5 @@ internal class CodeiumProposalManager : ProposalManagerBase
         return value;
     }
 }
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/CodeiumVS/Proposal/CodeiumProposalManagerProvider.cs
+++ b/CodeiumVS/Proposal/CodeiumProposalManagerProvider.cs
@@ -7,6 +7,8 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace CodeiumVS;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 [Export(typeof(ProposalManagerProviderBase))]
 [Name("CodeiumProposalManagerProvider")]
 [Order(Before = "InlineCSharpProposalManagerProvider")]
@@ -19,3 +21,5 @@ internal class CodeiumProposalManagerProvider : ProposalManagerProviderBase
         return CodeiumProposalManager.TryCreateAsync(view, this);
     }
 }
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/CodeiumVS/Proposal/CodeiumProposalSource.cs
+++ b/CodeiumVS/Proposal/CodeiumProposalSource.cs
@@ -12,6 +12,7 @@ using CodeiumVS.Languages;
 
 namespace CodeiumVS;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 internal class CodeiumProposalSource : ProposalSourceBase
 {
 
@@ -43,7 +44,7 @@ internal class CodeiumProposalSource : ProposalSourceBase
 	{
 		_document.FileActionOccurred -= OnFileActionOccurred;
 		_document.TextBuffer.ContentTypeChanged -= OnContentTypeChanged;
-		UpdateRequestTokenSource(null, "source is being disposed");
+		UpdateRequestTokenSource(null);
 		return base.DisposeAsync();
 	}
 
@@ -69,7 +70,7 @@ internal class CodeiumProposalSource : ProposalSourceBase
 
         CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cancellationToken = cancellationTokenSource.Token;
-        UpdateRequestTokenSource(cancellationTokenSource, "new proposal requested");
+        UpdateRequestTokenSource(cancellationTokenSource);
 
         if (completionState != null)
         {
@@ -113,7 +114,7 @@ internal class CodeiumProposalSource : ProposalSourceBase
         }
     }
 
-    private void UpdateRequestTokenSource(CancellationTokenSource newSource, string reason)
+    private void UpdateRequestTokenSource(CancellationTokenSource newSource)
     {
         CancellationTokenSource cancellationTokenSource = Interlocked.Exchange(ref _requestTokenSource, newSource);
         if (cancellationTokenSource != null)
@@ -191,3 +192,5 @@ internal class CodeiumProposalSource : ProposalSourceBase
     }
 
 }
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/CodeiumVS/Utilities/MefProvider.cs
+++ b/CodeiumVS/Utilities/MefProvider.cs
@@ -50,7 +50,7 @@ internal class MefProvider
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             // sastify mef import
-            _compositionService = Requires.NotNull(await ServiceProvider.GetGlobalServiceAsync(typeof(SComponentModel)) as IComponentModel);
+            _compositionService = Requires.NotNull(await ServiceProvider.GetGlobalServiceAsync(typeof(SComponentModel)) as IComponentModel, "_compositionService");
             _compositionService.DefaultCompositionService.SatisfyImportsOnce(this);
 
             // disabled because not needed right now


### PR DESCRIPTION
Opting for the latest SDK version inadvertently limited the versions of assemblies we could use. Initially, I assumed that the extension could reference any assemblies with the same name, similar to the behavior in C++. However, I discovered that there is a specific version requirement for referencing assemblies.

The required assemblies for SDK v17.5.33428.388 can be viewed [here](https://www.nuget.org/packages/Microsoft.VisualStudio.SDK/17.5.33428.388#dependencies-body-tab).

Some of the downsides of this are:
- The inline diff adornment can't check if there was a peek session that overlaps it anymore because `InterLineAdornmentTag` only exists in 17.8.37222 and above. It will now close any peek sessions that are in the same text view.
- We must use some ugly reflections in the proposals, because `SuggestionAcceptedEventArgs` only exists in SDK >=17.6.36389, potentially rendering the `OnSuggestionAccepted` useless in VS <17.6
- Had to suppress deprecated warnings in the proposal classes.

The inability to install earlier versions of VS continues to pose challenges for development and testing.