### PR TITLE
Proto migrations, ide name fix 

### DIFF
--- a/CodeiumVS.sln
+++ b/CodeiumVS.sln
@@ -15,8 +15,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|arm64.ActiveCfg = Debug|arm64
 		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|arm64.Build.0 = Debug|arm64
 		{B37F2AE5-CDEC-45B3-944D-8EF912810A12}.Debug|x86.ActiveCfg = Debug|x86

--- a/CodeiumVS/LanguageServer/LanguageServer.cs
+++ b/CodeiumVS/LanguageServer/LanguageServer.cs
@@ -66,7 +66,7 @@ public class LanguageServer
         await PrepareAsync();
 
         _metadata.request_id = 0;
-        _metadata.ide_name = "visual_studio";
+        _metadata.ide_name = "vscode";
         _metadata.ide_version = ideVersion;
         _metadata.extension_name = Vsix.Name;
         _metadata.extension_version = _languageServerVersion;

--- a/CodeiumVS/LanguageServer/LanguageServer.cs
+++ b/CodeiumVS/LanguageServer/LanguageServer.cs
@@ -780,8 +780,8 @@ public class LanguageServer
                                        language = language.Type,
                                        cursor_offset = (ulong)cursorPosition,
                                        line_ending = lineEnding,
-                                       absolute_path = absolutePath,
-                                       relative_path = Path.GetFileName(absolutePath) },
+                                       absolute_uri = absolutePath,
+                                       workspace_uri = Path.GetFileName(absolutePath) },
                     editor_options = new() {
                         tab_size = (ulong)tabSize,
                         insert_spaces = insertSpaces,
@@ -845,8 +845,8 @@ public class LanguageServer
                     language = language.Type,
                     cursor_offset = (ulong)cursorPosition,
                     line_ending = "\n",
-                    absolute_path = absolutePath,
-                    relative_path = Path.GetFileName(absolutePath)
+                    absolute_uri = absolutePath,
+                    workspace_uri = Path.GetFileName(absolutePath)
                 },
             };
 
@@ -873,8 +873,8 @@ public class LanguageServer
                     language = language.Type,
                     cursor_offset = (ulong)cursorPosition,
                     line_ending = "\n",
-                    absolute_path = absolutePath,
-                    relative_path = Path.GetFileName(absolutePath)
+                    absolute_uri = absolutePath,
+                    workspace_uri = Path.GetFileName(absolutePath)
                 },
             };
 

--- a/CodeiumVS/LanguageServer/LanguageServer.cs
+++ b/CodeiumVS/LanguageServer/LanguageServer.cs
@@ -781,7 +781,7 @@ public class LanguageServer
                                        cursor_offset = (ulong)cursorPosition,
                                        line_ending = lineEnding,
                                        absolute_path = absolutePath,
-                                       workspace_uri = Path.GetFileName(absolutePath) },
+                                       relative_path = Path.GetFileName(absolutePath) },
                     editor_options = new() {
                         tab_size = (ulong)tabSize,
                         insert_spaces = insertSpaces,
@@ -846,7 +846,7 @@ public class LanguageServer
                     cursor_offset = (ulong)cursorPosition,
                     line_ending = "\n",
                     absolute_path = absolutePath,
-                    workspace_uri = Path.GetFileName(absolutePath)
+                    relative_path = Path.GetFileName(absolutePath)
                 },
             };
 
@@ -874,7 +874,7 @@ public class LanguageServer
                     cursor_offset = (ulong)cursorPosition,
                     line_ending = "\n",
                     absolute_path = absolutePath,
-                    workspace_uri = Path.GetFileName(absolutePath)
+                    relative_path = Path.GetFileName(absolutePath)
                 },
             };
 

--- a/CodeiumVS/LanguageServer/LanguageServer.cs
+++ b/CodeiumVS/LanguageServer/LanguageServer.cs
@@ -781,6 +781,7 @@ public class LanguageServer
                                        cursor_offset = (ulong)cursorPosition,
                                        line_ending = lineEnding,
                                        absolute_path = absolutePath,
+                                       absolute_path_migrate_me_to_uri = absolutePath,
                                        relative_path = Path.GetFileName(absolutePath) },
                     editor_options = new() {
                         tab_size = (ulong)tabSize,

--- a/CodeiumVS/LanguageServer/LanguageServer.cs
+++ b/CodeiumVS/LanguageServer/LanguageServer.cs
@@ -66,6 +66,7 @@ public class LanguageServer
         await PrepareAsync();
 
         _metadata.request_id = 0;
+        // TODO: Change name
         _metadata.ide_name = "vscode";
         _metadata.ide_version = ideVersion;
         _metadata.extension_name = Vsix.Name;

--- a/CodeiumVS/LanguageServer/LanguageServer.cs
+++ b/CodeiumVS/LanguageServer/LanguageServer.cs
@@ -780,7 +780,7 @@ public class LanguageServer
                                        language = language.Type,
                                        cursor_offset = (ulong)cursorPosition,
                                        line_ending = lineEnding,
-                                       absolute_uri = absolutePath,
+                                       absolute_path = absolutePath,
                                        workspace_uri = Path.GetFileName(absolutePath) },
                     editor_options = new() {
                         tab_size = (ulong)tabSize,
@@ -845,7 +845,7 @@ public class LanguageServer
                     language = language.Type,
                     cursor_offset = (ulong)cursorPosition,
                     line_ending = "\n",
-                    absolute_uri = absolutePath,
+                    absolute_path = absolutePath,
                     workspace_uri = Path.GetFileName(absolutePath)
                 },
             };
@@ -873,7 +873,7 @@ public class LanguageServer
                     language = language.Type,
                     cursor_offset = (ulong)cursorPosition,
                     line_ending = "\n",
-                    absolute_uri = absolutePath,
+                    absolute_path = absolutePath,
                     workspace_uri = Path.GetFileName(absolutePath)
                 },
             };

--- a/CodeiumVS/LanguageServer/LanguageServerController.cs
+++ b/CodeiumVS/LanguageServer/LanguageServerController.cs
@@ -42,7 +42,7 @@ public class LanguageServerController
             {
                 var data = request.open_file_pointer;
                 OpenSelection(
-                    data.file_path, data.start_line, data.start_col, data.end_line, data.end_col);
+                    data.file_uri, data.start_line, data.start_col, data.end_line, data.end_col);
             }
             else if (request.ShouldSerializeinsert_at_cursor())
             {
@@ -64,7 +64,7 @@ public class LanguageServerController
                     }
                 }
 
-                ApplyDiff(data.file_path, data.diff.start_line, data.diff.end_line, replacement);
+                ApplyDiff(data.uri, data.diff.start_line, data.diff.end_line, replacement);
             }
         }
 
@@ -184,7 +184,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { explain_code_block = new() {
                 code_block_info = codeBlockInfo,
-                file_path = filePath,
+                uri = filePath,
                 language = language,
             } };
 
@@ -199,7 +199,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { explain_function = new() {
                 function_info = functionInfo,
-                file_path = filePath,
+                uri = filePath,
                 language = functionInfo.Language,
             } };
 
@@ -215,7 +215,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_unit_tests = new() {
                 function_info = functionInfo,
-                file_path = filePath,
+                uri = filePath,
                 language = functionInfo.Language,
                 instructions = instructions,
             } };
@@ -231,7 +231,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_docstring = new() {
                 function_info = functionInfo,
-                file_path = filePath,
+                uri = filePath,
                 language = functionInfo.Language,
             } };
 
@@ -246,7 +246,7 @@ public class LanguageServerController
         var request = WebChatServer.NewRequest();
         request.get_chat_message_request.chat_messages[0].intent =
             new() { code_block_refactor = new() { code_block_info = codeBlockInfo,
-                                                  file_path = filePath,
+                                                  uri = filePath,
                                                   language = language,
                                                   refactor_description = prompt } };
 
@@ -261,7 +261,7 @@ public class LanguageServerController
         var request = WebChatServer.NewRequest();
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_refactor = new() { function_info = functionInfo,
-                                                file_path = filePath,
+                                                uri = filePath,
                                                 language = functionInfo.Language,
                                                 refactor_description = prompt } };
 
@@ -298,7 +298,7 @@ public class LanguageServerController
             surrounding_code_snippet = span.Snapshot.GetText(
                 surroundingLineStart.Start, surroundingLineEnd.End - surroundingLineStart.Start),
             language = Languages.Mapper.GetLanguage(span.Snapshot.TextBuffer.ContentType).Type,
-            file_path = span.Snapshot.TextBuffer.GetFileName(),
+            uri = span.Snapshot.TextBuffer.GetFileName(),
             line_number = problemLineStart.LineNumber + 1,
         } };
 

--- a/CodeiumVS/LanguageServer/LanguageServerController.cs
+++ b/CodeiumVS/LanguageServer/LanguageServerController.cs
@@ -42,7 +42,7 @@ public class LanguageServerController
             {
                 var data = request.open_file_pointer;
                 OpenSelection(
-                    data.file_uri, data.start_line, data.start_col, data.end_line, data.end_col);
+                    data.file_path, data.start_line, data.start_col, data.end_line, data.end_col);
             }
             else if (request.ShouldSerializeinsert_at_cursor())
             {
@@ -64,7 +64,7 @@ public class LanguageServerController
                     }
                 }
 
-                ApplyDiff(data.uri, data.diff.start_line, data.diff.end_line, replacement);
+                ApplyDiff(data.file_path, data.diff.start_line, data.diff.end_line, replacement);
             }
         }
 
@@ -184,7 +184,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { explain_code_block = new() {
                 code_block_info = codeBlockInfo,
-                uri = filePath,
+                file_path = filePath,
                 language = language,
             } };
 
@@ -199,7 +199,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { explain_function = new() {
                 function_info = functionInfo,
-                uri = filePath,
+                file_path = filePath,
                 language = functionInfo.Language,
             } };
 
@@ -215,7 +215,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_unit_tests = new() {
                 function_info = functionInfo,
-                uri = filePath,
+                file_path = filePath,
                 language = functionInfo.Language,
                 instructions = instructions,
             } };
@@ -231,7 +231,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_docstring = new() {
                 function_info = functionInfo,
-                uri = filePath,
+                file_path = filePath,
                 language = functionInfo.Language,
             } };
 
@@ -246,7 +246,7 @@ public class LanguageServerController
         var request = WebChatServer.NewRequest();
         request.get_chat_message_request.chat_messages[0].intent =
             new() { code_block_refactor = new() { code_block_info = codeBlockInfo,
-                                                  uri = filePath,
+                                                  file_path = filePath,
                                                   language = language,
                                                   refactor_description = prompt } };
 
@@ -261,7 +261,7 @@ public class LanguageServerController
         var request = WebChatServer.NewRequest();
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_refactor = new() { function_info = functionInfo,
-                                                uri = filePath,
+                                                file_path = filePath,
                                                 language = functionInfo.Language,
                                                 refactor_description = prompt } };
 
@@ -298,7 +298,7 @@ public class LanguageServerController
             surrounding_code_snippet = span.Snapshot.GetText(
                 surroundingLineStart.Start, surroundingLineEnd.End - surroundingLineStart.Start),
             language = Languages.Mapper.GetLanguage(span.Snapshot.TextBuffer.ContentType).Type,
-            uri = span.Snapshot.TextBuffer.GetFileName(),
+            file_path = span.Snapshot.TextBuffer.GetFileName(),
             line_number = problemLineStart.LineNumber + 1,
         } };
 

--- a/CodeiumVS/LanguageServer/LanguageServerController.cs
+++ b/CodeiumVS/LanguageServer/LanguageServerController.cs
@@ -40,9 +40,10 @@ public class LanguageServerController
 
             if (request.ShouldSerializeopen_file_pointer())
             {
+
                 var data = request.open_file_pointer;
                 OpenSelection(
-                    data.file_path, data.start_line, data.start_col, data.end_line, data.end_col);
+                     data.file_path_migrate_me_to_uri.IsNullOrEmpty() ? data.file_path : data.file_path_migrate_me_to_uri, data.start_line, data.start_col, data.end_line, data.end_col);
             }
             else if (request.ShouldSerializeinsert_at_cursor())
             {
@@ -64,7 +65,7 @@ public class LanguageServerController
                     }
                 }
 
-                ApplyDiff(data.file_path, data.diff.start_line, data.diff.end_line, replacement);
+                ApplyDiff(data.file_path_migrate_me_to_uri.IsNullOrEmpty() ? data.file_path : data.file_path_migrate_me_to_uri, data.diff.start_line, data.diff.end_line, replacement);
             }
         }
 
@@ -185,6 +186,7 @@ public class LanguageServerController
             new() { explain_code_block = new() {
                 code_block_info = codeBlockInfo,
                 file_path = filePath,
+                file_path_migrate_me_to_uri = filePath,
                 language = language,
             } };
 
@@ -200,6 +202,7 @@ public class LanguageServerController
             new() { explain_function = new() {
                 function_info = functionInfo,
                 file_path = filePath,
+                file_path_migrate_me_to_uri = filePath,
                 language = functionInfo.Language,
             } };
 
@@ -216,6 +219,7 @@ public class LanguageServerController
             new() { function_unit_tests = new() {
                 function_info = functionInfo,
                 file_path = filePath,
+                file_path_migrate_me_to_uri = filePath,
                 language = functionInfo.Language,
                 instructions = instructions,
             } };
@@ -232,6 +236,7 @@ public class LanguageServerController
             new() { function_docstring = new() {
                 function_info = functionInfo,
                 file_path = filePath,
+                file_path_migrate_me_to_uri = filePath,
                 language = functionInfo.Language,
             } };
 
@@ -247,6 +252,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { code_block_refactor = new() { code_block_info = codeBlockInfo,
                                                   file_path = filePath,
+                                                  file_path_migrate_me_to_uri = filePath,
                                                   language = language,
                                                   refactor_description = prompt } };
 
@@ -262,6 +268,7 @@ public class LanguageServerController
         request.get_chat_message_request.chat_messages[0].intent =
             new() { function_refactor = new() { function_info = functionInfo,
                                                 file_path = filePath,
+                                                file_path_migrate_me_to_uri = filePath,
                                                 language = functionInfo.Language,
                                                 refactor_description = prompt } };
 
@@ -299,6 +306,7 @@ public class LanguageServerController
                 surroundingLineStart.Start, surroundingLineEnd.End - surroundingLineStart.Start),
             language = Languages.Mapper.GetLanguage(span.Snapshot.TextBuffer.ContentType).Type,
             file_path = span.Snapshot.TextBuffer.GetFileName(),
+            file_path_migrate_me_to_uri = span.Snapshot.TextBuffer.GetFileName(),
             line_number = problemLineStart.LineNumber + 1,
         } };
 

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -189,6 +189,13 @@ public partial class Document : global::ProtoBuf.IExtensible
     // changing this to the updated proto name breaks it, keeping it absolute_path for now
     public string absolute_uri { get; set; } = "";
 
+    [global::ProtoBuf.ProtoMember(2)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string relative_path
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(13)]
     [global::System.ComponentModel.DefaultValue("")]
     public string workspace_uri {
@@ -406,6 +413,10 @@ public partial class CodeContextItem : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string absolute_path { get; set; } = "";
+
     [global::ProtoBuf.ProtoMember(16)]
     [global::System.ComponentModel.DefaultValue("")]
     public string absolute_uri { get; set; } = "";
@@ -481,6 +492,10 @@ public partial class WorkspacePath : global::ProtoBuf.IExtensible
     global::ProtoBuf.IExtension
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
+
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string workspace { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1292,8 +1307,20 @@ public partial class GetChatMessageRequest : global::ProtoBuf.IExtensible
         get; set;
     }
 
+    [global::ProtoBuf.ProtoMember(6)]
+    public global::System.Collections.Generic.List<string> open_document_paths
+    {
+        get;
+    } = new global::System.Collections.Generic.List<string>();
+
     [global::ProtoBuf.ProtoMember(12)]
     public global::System.Collections.Generic.List<string> open_document_uris {
+        get;
+    } = new global::System.Collections.Generic.List<string>();
+
+    [global::ProtoBuf.ProtoMember(7)]
+    public global::System.Collections.Generic.List<string> workspace_paths
+    {
         get;
     } = new global::System.Collections.Generic.List<string>();
 
@@ -1525,6 +1552,13 @@ public partial class IntentFunctionExplain : global::ProtoBuf.IExtensible
         get; set;
     }
 
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
     public string uri {
@@ -1600,6 +1634,13 @@ public partial class IntentFunctionDocstring : global::ProtoBuf.IExtensible
         get; set;
     }
 
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
     public string uri {
@@ -1622,6 +1663,13 @@ public partial class IntentFunctionRefactor : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1651,6 +1699,13 @@ public partial class IntentCodeBlockExplain : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1708,6 +1763,13 @@ public partial class IntentCodeBlockRefactor : global::ProtoBuf.IExtensible
         get; set;
     }
 
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
     public string uri {
@@ -1736,6 +1798,12 @@ public partial class IntentFunctionUnitTests : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1778,6 +1846,13 @@ public partial class IntentProblemExplain : global::ProtoBuf.IExtensible
         get; set;
     }
 
+    [global::ProtoBuf.ProtoMember(5)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(7)]
     [global::System.ComponentModel.DefaultValue("")]
     public string uri {
@@ -1807,6 +1882,13 @@ public partial class IntentGenerateCode : global::ProtoBuf.IExtensible
         get; set;
     }
 
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
     public string uri {
@@ -1834,6 +1916,13 @@ public partial class IntentClassExplain : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1956,6 +2045,13 @@ public partial class ChatMessageActionEdit : global::ProtoBuf.IExtensible
     global::ProtoBuf.IExtension
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
+
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(6)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -2219,6 +2315,13 @@ public partial class ApplyDiff : global::ProtoBuf.IExtensible
     [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
     public string message_id { get; set; } = "";
+
+    [global::ProtoBuf.ProtoMember(2)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(8)]
     [global::System.ComponentModel.DefaultValue("")]

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -179,13 +179,13 @@ public partial class Document : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
-    [global::ProtoBuf.ProtoMember(1)]
+    [global::ProtoBuf.ProtoMember(12)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string absolute_path { get; set; } = "";
+    public string absolute_uri { get; set; } = "";
 
-    [global::ProtoBuf.ProtoMember(2)]
+    [global::ProtoBuf.ProtoMember(13)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string relative_path {
+    public string workspace_uri {
         get; set;
     } = "";
 
@@ -400,9 +400,9 @@ public partial class CodeContextItem : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
-    [global::ProtoBuf.ProtoMember(1)]
+    [global::ProtoBuf.ProtoMember(16)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string absolute_path { get; set; } = "";
+    public string absolute_uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(2)]
     public global::System.Collections.Generic.List<WorkspacePath> workspace_paths {
@@ -476,9 +476,9 @@ public partial class WorkspacePath : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
-    [global::ProtoBuf.ProtoMember(1)]
+    [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string workspace { get; set; } = "";
+    public string workspace_uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(2)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -750,6 +750,13 @@ public partial class CompletionsRequest : global::ProtoBuf.IExtensible
         get; set;
     } = "";
 
+    [global::ProtoBuf.ProtoMember(21)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string context_prompt
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(8)]
     public global::System.Collections.Generic.List<PromptElementRange> prompt_element_ranges {
         get;
@@ -771,6 +778,12 @@ public partial class CompletionsRequest : global::ProtoBuf.IExtensible
         get;
     } = new global::System.Collections.Generic.List<PromptStageLatency>();
 
+    [global::ProtoBuf.ProtoMember(20)]
+    public ulong num_tokenized_bytes
+    {
+        get; set;
+    }
+
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
     public string editor_language {
@@ -784,25 +797,39 @@ public partial class CompletionsRequest : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string absolute_path {
+    public string absolute_path_uri_for_telemetry {
         get; set;
     } = "";
 
     [global::ProtoBuf.ProtoMember(6)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string relative_path {
+    public string relative_path_for_telemetry {
         get; set;
     } = "";
 
     [global::ProtoBuf.ProtoMember(13)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string workspace {
+    public string workspace_uri_for_telemetry {
         get; set;
     } = "";
 
     [global::ProtoBuf.ProtoMember(7)]
     [global::System.ComponentModel.DefaultValue("")]
     public string experiment_features_json {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(19)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string experiment_variant_json
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(10)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string model
+    {
         get; set;
     } = "";
 
@@ -831,6 +858,14 @@ public partial class CompletionsRequest : global::ProtoBuf.IExtensible
     public global::System.Collections.Generic.List<string> experiment_tags {
         get;
     } = new global::System.Collections.Generic.List<string>();
+
+    [global::ProtoBuf.ProtoMember(22)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string eval_suffix
+    {
+        get; set;
+    } = "";
+
 }
 
 [global::ProtoBuf.ProtoContract()]
@@ -1251,13 +1286,13 @@ public partial class GetChatMessageRequest : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(6)]
-    public global::System.Collections.Generic.List<string> open_document_paths {
+    [global::ProtoBuf.ProtoMember(12)]
+    public global::System.Collections.Generic.List<string> open_document_uris {
         get;
     } = new global::System.Collections.Generic.List<string>();
 
-    [global::ProtoBuf.ProtoMember(7)]
-    public global::System.Collections.Generic.List<string> workspace_paths {
+    [global::ProtoBuf.ProtoMember(13)]
+    public global::System.Collections.Generic.List<string> workspace_uris {
         get;
     } = new global::System.Collections.Generic.List<string>();
 
@@ -1484,9 +1519,9 @@ public partial class IntentFunctionExplain : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 }
@@ -1559,9 +1594,9 @@ public partial class IntentFunctionDocstring : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 }
@@ -1582,9 +1617,9 @@ public partial class IntentFunctionRefactor : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 
@@ -1611,9 +1646,9 @@ public partial class IntentCodeBlockExplain : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 }
@@ -1667,9 +1702,9 @@ public partial class IntentCodeBlockRefactor : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 
@@ -1696,9 +1731,9 @@ public partial class IntentFunctionUnitTests : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 
@@ -1737,9 +1772,9 @@ public partial class IntentProblemExplain : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(5)]
+    [global::ProtoBuf.ProtoMember(7)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 
@@ -1766,9 +1801,9 @@ public partial class IntentGenerateCode : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 
@@ -1794,9 +1829,9 @@ public partial class IntentClassExplain : global::ProtoBuf.IExtensible
         get; set;
     }
 
-    [global::ProtoBuf.ProtoMember(3)]
+    [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 }
@@ -1916,9 +1951,9 @@ public partial class ChatMessageActionEdit : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
-    [global::ProtoBuf.ProtoMember(1)]
+    [global::ProtoBuf.ProtoMember(6)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path { get; set; } = "";
+    public string uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(2)]
     public DiffBlock diff {
@@ -2111,9 +2146,9 @@ public partial class OpenFilePointer : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
-    [global::ProtoBuf.ProtoMember(1)]
+    [global::ProtoBuf.ProtoMember(6)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path { get; set; } = "";
+    public string file_uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(2)]
     public int start_line {
@@ -2179,9 +2214,9 @@ public partial class ApplyDiff : global::ProtoBuf.IExtensible
     [global::System.ComponentModel.DefaultValue("")]
     public string message_id { get; set; } = "";
 
-    [global::ProtoBuf.ProtoMember(2)]
+    [global::ProtoBuf.ProtoMember(8)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string file_path {
+    public string uri {
         get; set;
     } = "";
 

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -2246,6 +2246,10 @@ public partial class OpenFilePointer : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path { get; set; } = "";
+
     [global::ProtoBuf.ProtoMember(6)]
     [global::System.ComponentModel.DefaultValue("")]
     public string file_uri { get; set; } = "";

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -181,6 +181,7 @@ public partial class Document : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(12)]
     [global::System.ComponentModel.DefaultValue("")]
+    // changing this to the updated proto name breaks it, keeping it absolute_path for now
     public string absolute_path { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(13)]

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -179,10 +179,15 @@ public partial class Document : global::ProtoBuf.IExtensible
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
 
-    [global::ProtoBuf.ProtoMember(12)]
+    [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
     // changing this to the updated proto name breaks it, keeping it absolute_path for now
     public string absolute_path { get; set; } = "";
+
+    [global::ProtoBuf.ProtoMember(12)]
+    [global::System.ComponentModel.DefaultValue("")]
+    // changing this to the updated proto name breaks it, keeping it absolute_path for now
+    public string absolute_uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(13)]
     [global::System.ComponentModel.DefaultValue("")]

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -181,12 +181,10 @@ public partial class Document : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
-    // changing this to the updated proto name breaks it, keeping it absolute_path for now
     public string absolute_path { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(12)]
     [global::System.ComponentModel.DefaultValue("")]
-    // changing this to the updated proto name breaks it, keeping it absolute_path for now
     public string absolute_uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(2)]

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -183,9 +183,20 @@ public partial class Document : global::ProtoBuf.IExtensible
     [global::System.ComponentModel.DefaultValue("")]
     public string absolute_path { get; set; } = "";
 
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string absolute_path_migrate_me_to_uri { get; set; } = "";
+
     [global::ProtoBuf.ProtoMember(12)]
     [global::System.ComponentModel.DefaultValue("")]
     public string absolute_uri { get; set; } = "";
+
+    [global::ProtoBuf.ProtoMember(2)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string relative_path_migrate_me_to_workspace_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(2)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -415,6 +426,10 @@ public partial class CodeContextItem : global::ProtoBuf.IExtensible
     [global::System.ComponentModel.DefaultValue("")]
     public string absolute_path { get; set; } = "";
 
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string absolute_path_migrate_me_to_uri { get; set; } = "";
+
     [global::ProtoBuf.ProtoMember(16)]
     [global::System.ComponentModel.DefaultValue("")]
     public string absolute_uri { get; set; } = "";
@@ -494,6 +509,10 @@ public partial class WorkspacePath : global::ProtoBuf.IExtensible
     [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
     public string workspace { get; set; } = "";
+
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string workspace_migrate_me_to_uri { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -816,13 +835,34 @@ public partial class CompletionsRequest : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string absolute_path
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(5)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string absolute_path_uri_for_telemetry {
         get; set;
     } = "";
 
     [global::ProtoBuf.ProtoMember(6)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string relative_path
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(6)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string relative_path_for_telemetry {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(13)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string workspace
+    {
         get; set;
     } = "";
 
@@ -1311,6 +1351,12 @@ public partial class GetChatMessageRequest : global::ProtoBuf.IExtensible
         get;
     } = new global::System.Collections.Generic.List<string>();
 
+    [global::ProtoBuf.ProtoMember(6)]
+    public global::System.Collections.Generic.List<string> open_document_paths_migrate_me_to_uris
+    {
+        get;
+    } = new global::System.Collections.Generic.List<string>();
+
     [global::ProtoBuf.ProtoMember(12)]
     public global::System.Collections.Generic.List<string> open_document_uris {
         get;
@@ -1318,6 +1364,12 @@ public partial class GetChatMessageRequest : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(7)]
     public global::System.Collections.Generic.List<string> workspace_paths
+    {
+        get;
+    } = new global::System.Collections.Generic.List<string>();
+
+    [global::ProtoBuf.ProtoMember(7)]
+    public global::System.Collections.Generic.List<string> workspace_paths_migrate_me_to_uris
     {
         get;
     } = new global::System.Collections.Generic.List<string>();
@@ -1552,6 +1604,13 @@ public partial class IntentFunctionExplain : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string file_path
     {
         get; set;
@@ -1639,6 +1698,13 @@ public partial class IntentFunctionDocstring : global::ProtoBuf.IExtensible
         get; set;
     } = "";
 
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
+
     [global::ProtoBuf.ProtoMember(4)]
     [global::System.ComponentModel.DefaultValue("")]
     public string uri {
@@ -1661,6 +1727,13 @@ public partial class IntentFunctionRefactor : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1697,6 +1770,13 @@ public partial class IntentCodeBlockExplain : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1763,6 +1843,13 @@ public partial class IntentCodeBlockRefactor : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string file_path
     {
         get; set;
@@ -1796,6 +1883,13 @@ public partial class IntentFunctionUnitTests : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -1846,6 +1940,13 @@ public partial class IntentProblemExplain : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(5)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(5)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string file_path
     {
         get; set;
@@ -1882,6 +1983,13 @@ public partial class IntentGenerateCode : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string file_path
     {
         get; set;
@@ -1914,6 +2022,13 @@ public partial class IntentClassExplain : global::ProtoBuf.IExtensible
     public Language language {
         get; set;
     }
+
+    [global::ProtoBuf.ProtoMember(3)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(3)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -2043,6 +2158,13 @@ public partial class ChatMessageActionEdit : global::ProtoBuf.IExtensible
     global::ProtoBuf.IExtension
         global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing) =>
         global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
+
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
@@ -2248,6 +2370,13 @@ public partial class OpenFilePointer : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
+
+    [global::ProtoBuf.ProtoMember(1)]
+    [global::System.ComponentModel.DefaultValue("")]
     public string file_path { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(6)]
@@ -2317,6 +2446,13 @@ public partial class ApplyDiff : global::ProtoBuf.IExtensible
     [global::ProtoBuf.ProtoMember(1)]
     [global::System.ComponentModel.DefaultValue("")]
     public string message_id { get; set; } = "";
+
+    [global::ProtoBuf.ProtoMember(2)]
+    [global::System.ComponentModel.DefaultValue("")]
+    public string file_path_migrate_me_to_uri
+    {
+        get; set;
+    } = "";
 
     [global::ProtoBuf.ProtoMember(2)]
     [global::System.ComponentModel.DefaultValue("")]

--- a/CodeiumVS/LanguageServer/Packets.cs
+++ b/CodeiumVS/LanguageServer/Packets.cs
@@ -181,7 +181,7 @@ public partial class Document : global::ProtoBuf.IExtensible
 
     [global::ProtoBuf.ProtoMember(12)]
     [global::System.ComponentModel.DefaultValue("")]
-    public string absolute_uri { get; set; } = "";
+    public string absolute_path { get; set; } = "";
 
     [global::ProtoBuf.ProtoMember(13)]
     [global::System.ComponentModel.DefaultValue("")]

--- a/CodeiumVS/Windows/ChatToolWindow.cs
+++ b/CodeiumVS/Windows/ChatToolWindow.cs
@@ -21,7 +21,7 @@ public class ChatToolWindow : ToolWindowPane
     public ChatToolWindow() : base(null)
     {
         Instance = this;
-        Caption = "Codeiummm Chat";
+        Caption = "Codeium Chat";
         Content = new ChatToolWindowControl();
     }
 

--- a/CodeiumVS/Windows/ChatToolWindow.cs
+++ b/CodeiumVS/Windows/ChatToolWindow.cs
@@ -21,7 +21,7 @@ public class ChatToolWindow : ToolWindowPane
     public ChatToolWindow() : base(null)
     {
         Instance = this;
-        Caption = "Codeium Chat";
+        Caption = "Codeiummm Chat";
         Content = new ChatToolWindowControl();
     }
 

--- a/CodeiumVS/source.extension.vsixmanifest
+++ b/CodeiumVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Codeium.VisualStudio" Version="1.8.82" Language="en-US" Publisher="Codeium" />
+        <Identity Id="Codeium.VisualStudio" Version="1.8.83" Language="en-US" Publisher="Codeium" />
         <DisplayName>Codeium</DisplayName>
         <Description xml:space="preserve">The modern coding superpower: free AI code acceleration plugin for your favorite languages. Type less. Code more. Ship faster.</Description>
         <MoreInfo>https://www.codeium.com</MoreInfo>


### PR DESCRIPTION
Proto was out of date in places, especially with internal changes changing some proto names. Changed those manually. Also kept the previous names for backward compatibility.

Ide name is causing issues on the ls side. Quick fix to assuage that until new release