### PR TITLE
Fix for github issue #101: Codeium only checked for \r and and not \n or \r\n when checking for end of line

### DIFF
--- a/CodeiumVS/SuggestionUI/StringCompare.cs
+++ b/CodeiumVS/SuggestionUI/StringCompare.cs
@@ -75,7 +75,7 @@ public static class StringCompare
 
         int index = suggestion.IndexOf(line);
         int endPos = index + line.Length;
-        int firstLineBreak = suggestion.IndexOf('\n');
+        int firstLineBreak = IndexOfNewLine(suggestion);
 
         if (index > -1 && (firstLineBreak == -1 || endPos < firstLineBreak))
         {
@@ -88,5 +88,22 @@ public static class StringCompare
             return res.Item1 >= endPoint ? res.Item2 : -1;
         }
     }
-}
+        
+    private static readonly System.Text.RegularExpressions.Regex newLineMatcher = new System.Text.RegularExpressions.Regex(@"(?:\r\n|\n|\r)",
+        System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.Singleline);
+
+    /// <summary>
+    /// Returns the index of the first new line in the string, or -1 if not found
+    /// </summary>
+    /// <remarks>Checks for both \r\n and \n</remarks>
+    public static int IndexOfNewLine(string text)
+    {
+        System.Text.RegularExpressions.Match newLineMatch = newLineMatcher.Match(text);
+
+        if (newLineMatch.Success)
+            return newLineMatch.Index;
+
+        return -1;
+    }
+    }
 }

--- a/CodeiumVS/SuggestionUI/TextViewListener.cs
+++ b/CodeiumVS/SuggestionUI/TextViewListener.cs
@@ -157,9 +157,10 @@ internal class CodeiumCompletionHandler : IOleCommandTarget, IDisposable
             String completionText = completionItems[i].completion.text;
             if (!String.IsNullOrEmpty(end))
             {
-                int endNewline = end.IndexOf('\r');
-                endNewline = endNewline <= -1 ? end.IndexOf('\n') : endNewline;
-                endNewline = endNewline <= -1 ? end.Length : endNewline;
+                int endNewline = StringCompare.IndexOfNewLine(end);
+
+                if (endNewline <= -1)
+                    endNewline = end.Length;
 
                 completionText = completionText + end.Substring(0, endNewline);
             }


### PR DESCRIPTION
Issue #101 highlights a problem where Codeium outputs significantly more text than it's meant to. This happens on any file which has both \r\n and \n for line endings. It's a fairly simple regex to check for both \r and \n and then just return the index of them.