### PR TITLE
Re-auth on failure, pin language server for specific portals

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set Release Condition
       id: check_release
       run: |
-        $isRelease = "${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/enterprise-release-v') && (github.actor == 'saranshsaini' || github.actor == 'fortenforge') }}"
+        $isRelease = "${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/enterprise-release-v') && (github.actor == 'edwardpark97' || github.actor == 'saranshsaini' || github.actor == 'fortenforge') }}"
         echo "IS_RELEASE=$isRelease" | Out-File -FilePath $env:GITHUB_ENV -Append
         if ($isRelease -eq 'true') {
           $tag = "${{ github.ref_name }}"


### PR DESCRIPTION
When asking for model inference fails on an Unauthenticated error, prompt the user to re-log in.

Also, pin the language server for specific portal URLs.

Also, change the github workflow to accept my username. Also fix some lint errors